### PR TITLE
use a daemon thread to get water tiles instead

### DIFF
--- a/scripts/units/ANIfrog.js
+++ b/scripts/units/ANIfrog.js
@@ -251,7 +251,7 @@ var map_valids = [];
 var map_valids_usable = false:
 var frog_thread = Threads.daemon(() => {
     while(true){
-        while(Vars.state.menu || Vars.net.server() || map_valids_usable);
+        while(Vars.net.server() || !Vars.state.isPlaying() || map_valids_usable);
         map_valids = get();
         map_valids_usable = true;
     }
@@ -262,7 +262,7 @@ Events.on(EventType.WorldLoadEvent, () => {
 });
 
 Events.on(Trigger.update.getClass(), () => {
-    if(Vars.state.menu || Vars.net.server() || !map_valids_usable || !Mathf.chanceDelta(0.0001) || !Vars.state.isPlaying()) return;
+    if(Vars.net.server() || !map_valids_usable || !Mathf.chanceDelta(0.0001) || !Vars.state.isPlaying()) return;
 
     if(map_valids.length > 0){
         //this can only spawn default teams frogs when there aren't any other teams in the current map

--- a/scripts/units/ANIfrog.js
+++ b/scripts/units/ANIfrog.js
@@ -247,18 +247,30 @@ frog.constructor = () => extend(MechUnit, {
 
 frog.defaultController = prov(() => extend(AIController, {}));
 
+var map_valids = [];
+var map_valids_usable = false:
+var frog_thread = Threads.daemon(() => {
+    while(true){
+        while(map_valids_usable);
+        map_valids = get();
+        map_valids_usable = true;
+    }
+});
+
+Events.on(EventType.WorldLoadEvent, () => {
+    map_valids_usable = false;
+});
+
 Events.on(Trigger.update.getClass(), () => {
-    if(!Mathf.chanceDelta(0.0001) || !Vars.state.isPlaying()) return;
+    if(!Mathf.chanceDelta(0.0001) || !Vars.state.isPlaying() || !map_valids_usable) return;
 
-    let valids = get();
-
-    if(valids.length > 0){
+    if(map_valids.length > 0){
         //this can only spawn default teams frogs when there aren't any other teams in the current map
         for(let i = 0; i < Team.baseTeams.length; i++){
             let team = rand(Team.baseTeams);
 
             if(team != Team.derelict && Units.canCreate(team, frog)){
-                spawn(team, rand(valids));
+                spawn(team, rand(map_valids));
 
                 if(!frog.unlocked && Vars.state.isCampaign()){
                     frog.unlock();

--- a/scripts/units/ANIfrog.js
+++ b/scripts/units/ANIfrog.js
@@ -251,7 +251,7 @@ var map_valids = [];
 var map_valids_usable = false:
 var frog_thread = Threads.daemon(() => {
     while(true){
-        while(map_valids_usable);
+        while(Vars.state.menu || Vars.net.server() || map_valids_usable);
         map_valids = get();
         map_valids_usable = true;
     }
@@ -262,7 +262,7 @@ Events.on(EventType.WorldLoadEvent, () => {
 });
 
 Events.on(Trigger.update.getClass(), () => {
-    if(!Mathf.chanceDelta(0.0001) || !Vars.state.isPlaying() || !map_valids_usable) return;
+    if(Vars.state.menu || Vars.net.server() || !map_valids_usable || !Mathf.chanceDelta(0.0001) || !Vars.state.isPlaying()) return;
 
     if(map_valids.length > 0){
         //this can only spawn default teams frogs when there aren't any other teams in the current map


### PR DESCRIPTION
# **this pr is untested because i'm clearly on mobile**
please test this and see if the game crashes for whatever reason
thanks

# what is this all about
so i was playing on mobile with your mod (in a 500x500 map, unfortunately) and it suddenly gets lagspikes for some reason, and suddenly frogs appear
i checked the source code and found the cause, which is checking all tiles in the main thread
coincidentally, i found out about threads in Mindustry days ago, so why not

- i clearly did not test this code because i'm on mobile
- daemon threads because why not, they just get all water tiles and that's it
- thank you for your time reading this